### PR TITLE
fix(app): fix delete and reset bugs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -261,6 +261,7 @@ func (m *home) handleKeyPress(msg tea.KeyMsg) (mod tea.Model, cmd tea.Cmd) {
 
 			if err := instance.Start(true); err != nil {
 				m.list.Kill()
+				m.state = stateDefault
 				return m.showErrorMessageForShortTime(err)
 			}
 			// Save after adding new instance

--- a/session/git/worktree_ops.go
+++ b/session/git/worktree_ops.go
@@ -210,5 +210,12 @@ func CleanupWorktrees() error {
 		}
 	}
 
+	// You have to prune the cleaned up worktrees.
+	cmd = exec.Command("git", "worktree", "prune")
+	_, err = cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to prune worktrees: %w", err)
+	}
+
 	return nil
 }

--- a/session/tmux/tmux.go
+++ b/session/tmux/tmux.go
@@ -50,15 +50,17 @@ type TmuxSession struct {
 	wg     *sync.WaitGroup
 }
 
-func removeWhitespace(str string) string {
+const TmuxPrefix = "claudesquad-"
+
+func toClaudeSquadTmuxName(str string) string {
 	re := regexp.MustCompile(`\s+`)
-	return re.ReplaceAllString(str, "")
+	return fmt.Sprintf("%s%s", TmuxPrefix, re.ReplaceAllString(str, ""))
 }
 
 func NewTmuxSession(name string) *TmuxSession {
 	return &TmuxSession{
 		Name:          name,
-		sanitizedName: removeWhitespace(name),
+		sanitizedName: toClaudeSquadTmuxName(name),
 	}
 }
 
@@ -345,7 +347,8 @@ func (t *TmuxSession) updateWindowSize(cols, rows int) error {
 
 // DoesSessionExist checks if a tmux session exists
 func DoesSessionExist(name string) bool {
-	existsCmd := exec.Command("tmux", "has-session", "-t", name)
+	// Using "-t name" does a prefix match, which is wrong. `-t=` does an exact match.
+	existsCmd := exec.Command("tmux", "has-session", fmt.Sprintf("-t=%s", name))
 	return existsCmd.Run() == nil
 }
 
@@ -387,7 +390,7 @@ func CleanupSessions() error {
 		return fmt.Errorf("failed to list tmux sessions: %v", err)
 	}
 
-	re := regexp.MustCompile(`^session-\d+`)
+	re := regexp.MustCompile(fmt.Sprintf(`^%s\d+`, TmuxPrefix))
 	matches := re.FindAllString(string(output), -1)
 
 	for _, match := range matches {


### PR DESCRIPTION
This change fixes bugs:
- On a name confict, we would not set the app state back to default
- The tmux `DoesSessionExist` did a prefix match previously. Now we do an exact match
- On `--reset` we now prune the worktrees. Before, we only cleaned up the dirs. No-pruning would cause a conflict when re-creating instances w/ the same names