### PR TITLE
fix(ui): make menu shorter and improve underlining

### DIFF
--- a/keys/keys.go
+++ b/keys/keys.go
@@ -20,7 +20,7 @@ const (
 	KeyTab        // Tab is a special keybinding for switching between panes.
 	KeySubmitName // SubmitName is a special keybinding for submitting the name of a new instance.
 
-	KeyPause
+	KeyCheckout
 	KeyResume
 	KeyPrompt // New key for entering a prompt
 
@@ -44,7 +44,7 @@ var GlobalKeyStringsMap = map[string]KeyName{
 	"d":          KeyKill,
 	"q":          KeyQuit,
 	"tab":        KeyTab,
-	"p":          KeyPause,
+	"c":          KeyCheckout,
 	"r":          KeyResume,
 	"s":          KeySubmit,
 }
@@ -61,11 +61,11 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 	),
 	KeyShiftUp: key.NewBinding(
 		key.WithKeys("shift+up"),
-		key.WithHelp("shift+↑", "scroll up"),
+		key.WithHelp("shift+↑", "scroll"),
 	),
 	KeyShiftDown: key.NewBinding(
 		key.WithKeys("shift+down"),
-		key.WithHelp("shift+↓", "scroll down"),
+		key.WithHelp("shift+↓", "scroll"),
 	),
 	KeyEnter: key.NewBinding(
 		key.WithKeys("enter", "o"),
@@ -91,9 +91,9 @@ var GlobalkeyBindings = map[KeyName]key.Binding{
 		key.WithKeys("N"),
 		key.WithHelp("N", "new with prompt"),
 	),
-	KeyPause: key.NewBinding(
-		key.WithKeys("p"),
-		key.WithHelp("p", "pause to checkout"),
+	KeyCheckout: key.NewBinding(
+		key.WithKeys("c"),
+		key.WithHelp("c", "checkout"),
 	),
 	KeyTab: key.NewBinding(
 		key.WithKeys("tab"),

--- a/ui/menu.go
+++ b/ui/menu.go
@@ -26,8 +26,8 @@ var sepStyle = lipgloss.NewStyle().Foreground(lipgloss.AdaptiveColor{
 
 var actionGroupStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("99"))
 
-var separator = "  •  "
-var verticalSeparator = "  │  "
+var separator = " • "
+var verticalSeparator = " │ "
 
 var menuStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("205"))
@@ -119,12 +119,12 @@ func (m *Menu) addInstanceOptions() {
 	if m.instance.Status == session.Paused {
 		actionGroup = append(actionGroup, keys.KeyResume)
 	} else {
-		actionGroup = append(actionGroup, keys.KeyPause)
+		actionGroup = append(actionGroup, keys.KeyCheckout)
 	}
 
 	// Navigation group (when in diff tab)
 	if m.isInDiffTab {
-		actionGroup = append(actionGroup, keys.KeyShiftUp, keys.KeyShiftDown)
+		actionGroup = append(actionGroup, keys.KeyShiftUp)
 	}
 
 	// System group


### PR DESCRIPTION
This change updates the "pause to checkout" action to just say "checkout". The action key is now "c" instead of "p". This makes the menu shorter.

Also, we now only show shift+up in the diff view. Having both up and down is overkill.

Finally, this changes fixes the `handleKeyPress` control flow when we are not doing menu highlighting. Before, we used to re-send the keypress. This is not efficient. Now, we just handle it in place.

<img width="1024" alt="image" src="https://github.com/user-attachments/assets/5b28aa7a-fc07-4a6c-83a2-17f60358b78d" />
